### PR TITLE
Upgrade template to use pan doc structure 

### DIFF
--- a/template/src/main.asm
+++ b/template/src/main.asm
@@ -19,12 +19,24 @@ SECTION  "start", ROM0[$0100]
 INCLUDE "header.inc"
 
 SECTION "variables", WRAM0
-pCOUNTER:: ds 3
+
+COUNTER_TIMER EQU 60
 pVBLANK_FLAG:: ds 1
+
+pCOUNTER:: ds 3
+pCOUNTER_TIMER:: ds 1
 
 SECTION "main", ROMX
 init::
   nop
+
+.reset_counter
+  xor a
+  ld [pCOUNTER], a
+
+.init_counter_timer
+  ld a, COUNTER_TIMER
+  ld [pCOUNTER_TIMER], a
 
 .wait_vblank_loop
   ld A, [pLCD_LINE_Y]
@@ -59,15 +71,20 @@ main_loop::
   xor a
   ld [pVBLANK_FLAG], a
 
-  call game_logic
-  jr main_loop
+  ld hl, pCOUNTER_TIMER
+  dec [hl]
+  jr nz, main_loop
 
-game_logic::
-  push hl
+.update_counter
   ld hl, pCOUNTER
   inc [hl]
-  pop hl
-  ret
+
+.reset_counter_timer
+  ld a, COUNTER_TIMER
+  ld [pCOUNTER_TIMER], a
+
+.continue
+  jr main_loop
 
 on_vblank::
   push af
@@ -76,5 +93,5 @@ on_vblank::
   ; And set the vblank flag
   ld a, 1
   ld [pVBLANK_FLAG], a
-  pop af 
+  pop af
   reti

--- a/template/src/main.asm
+++ b/template/src/main.asm
@@ -1,7 +1,7 @@
 include "addrs.inc"
 
 SECTION  "Vblank", ROM0[$0040]
-  reti
+  jp on_vblank
 SECTION  "LCDC", ROM0[$0048]
   reti
 SECTION  "Timer_Overflow", ROM0[$0050]
@@ -14,11 +14,67 @@ SECTION  "p1thru4", ROM0[$0060]
 ; Point-of-entry
 SECTION  "start", ROM0[$0100]
   nop
-  jp main
+  jp init
+
+INCLUDE "header.inc"
+
+SECTION "variables", WRAM0
+pCOUNTER:: ds 3
+pVBLANK_FLAG:: ds 1
 
 SECTION "main", ROMX
-
-main::
+init::
   nop
-.loop
-  jp .loop
+
+.wait_vblank_loop
+  ld A, [pLCD_LINE_Y]
+  cp 144
+  jr nz, .wait_vblank_loop
+
+.screen_off
+  di
+  ld hl, pLCD_CTRL
+  res 7, [hl]
+
+.set_interrupts_enabled
+  ld a, %00000001
+  ld [pINTERRUPT_ENABLE], a
+
+.screen_on
+  ei
+  ld hl, pLCD_CTRL
+  set 7, [hl]
+
+main_loop::
+  halt
+  nop
+
+  ; Vblank interrupt?
+  ld a, [pVBLANK_FLAG]
+  or a
+  ; No, some other interrupt
+  jr z, main_loop
+
+  ; Clear the vblank flag
+  xor a
+  ld [pVBLANK_FLAG], a
+
+  call game_logic
+  jr main_loop
+
+game_logic::
+  push hl
+  ld hl, pCOUNTER
+  inc [hl]
+  pop hl
+  ret
+
+on_vblank::
+  push af
+  ; Draw stuff...
+  nop
+  ; And set the vblank flag
+  ld a, 1
+  ld [pVBLANK_FLAG], a
+  pop af 
+  reti

--- a/template/src/main.asm
+++ b/template/src/main.asm
@@ -88,7 +88,7 @@ main_loop::
 
 on_vblank::
   push af
-  ; Draw stuff...
+  ; Draw stuff... a DMA transfer would happen here
   nop
   ; And set the vblank flag
   ld a, 1


### PR DESCRIPTION
Updates the template program to update a single-byte (non-BCD) counter after every v-blank interrupt. Approximately but not precisely 60 times a second, since no timers are used. This is the program structure recommended by the [pan docs](http://gameboy.mongenel.com/dmg/gbspec.txt) (under the "low-power mode" heading). 